### PR TITLE
Update corrs lol with index lookup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *~
 *.pyc
 .vscode/
+.*env*
 
 # Distribution / packaging
 .Python

--- a/ClosureInvariants/scalarInvariants.py
+++ b/ClosureInvariants/scalarInvariants.py
@@ -43,7 +43,7 @@ def corrupt_visibilities(vis: NP.ndarray, g_a: NP.ndarray, g_b: NP.ndarray) -> N
     if g_a.ndim != g_b.ndim:
         raise ValueError('Inputs g_a and g_b must have same number of dimensions')
     return g_a * vis * g_b.conj()
-
+        
 def corrs_list_on_loops(corrs: NP.ndarray, 
                         ant_pairs: List[Union[Tuple[Union[int, str], Union[int, str]], 
                                               List[Union[int, str]]]], 
@@ -121,28 +121,45 @@ def corrs_list_on_loops(corrs: NP.ndarray,
     elif loops.ndim != 2:
         raise ValueError('Input loops contains invalid shape')
 
+    # Map antenna label to integer index
+    ant_map = {}
+    for pair in ant_pairs:
+        for ant in pair:
+            if ant not in ant_map:
+                ant_map[ant] = len(ant_map)
+
+    # Lookup pair -> index and conjugation flag
+    pair_lookup = {}
+    for idx, (a, b) in enumerate(ant_pairs):
+        a_idx, b_idx = ant_map[a], ant_map[b]
+        pair_lookup[(a_idx, b_idx)] = (idx, False)
+        pair_lookup[(b_idx, a_idx)] = (idx, True)
+
+    # Convert loops to integer indices, skip missing
+    loops_idx = []
+    for loop in loops:
+        try:
+            loops_idx.append([ant_map[a] for a in loop])
+        except KeyError:
+            continue
+
     corrs_lol = []
-    for loopi, loop in enumerate(loops):
+    for loop in loops_idx:
         corrs_loop = []
-        for i in range(len(loop)):
-            bl_ind = NP.where((ant_pairs[:,0] == loop[i]) & (ant_pairs[:,1]==loop[(i+1)%loop.size]))[0]
-            if bl_ind.size == 1:
-                corr = NP.copy(NP.take(corrs, bl_ind, axis=bl_axis))
-            elif bl_ind.size == 0: # Check for reversed pair
-                bl_ind = NP.where((ant_pairs[:,0] == loop[(i+1)%loop.size]) & (ant_pairs[:,1]==loop[i]))[0]
-                if bl_ind.size == 0:
-                    raise IndexError('Specified antenna pair ({0:0d},{1:0d}) not found in input ant_pairs'.format(loop[i], loop[(i+1)%loop.size]))
-                elif bl_ind.size == 1: # Take conjugate
-                    corr = NP.take(corrs.conj(), bl_ind, axis=bl_axis)
-                elif bl_ind.size > 1:
-                    raise IndexError('{0:0d} indices found for antenna pair ({1:0d},{2:0d}) in input ant_pairs'.format(bl_ind, loop[i], loop[(i+1)%loop.size]))
-            elif bl_ind.size > 1:
-                raise IndexError('{0:0d} indices found for antenna pair ({1:0d},{2:0d}) in input ant_pairs'.format(bl_ind, loop[i], loop[(i+1)%loop.size]))
-        
-            corr = NP.take(corr, 0, axis=bl_axis)
-            corrs_loop += [corr]
-        corrs_lol += [corrs_loop]
-        
+        n = len(loop)
+        for i in range(n):
+            a, b = loop[i], loop[(i + 1) % n]
+            lookup = pair_lookup.get((a, b))
+            if lookup is not None:
+                idx, conj = lookup
+                corr = NP.copy(NP.take(corrs, idx, axis=bl_axis))
+                if conj:
+                    corr = corr.conj()
+                corrs_loop.append(corr)
+            else:
+                break
+        if len(corrs_loop) == n:
+            corrs_lol.append(corrs_loop)
     return corrs_lol
 
 def advariant(corrs_list: Union[List[List[NP.ndarray]], List[NP.ndarray]]) -> NP.ndarray:

--- a/ClosureInvariants/scalarInvariants_torch.py
+++ b/ClosureInvariants/scalarInvariants_torch.py
@@ -165,6 +165,8 @@ def corrs_list_on_loops(corrs: torch.Tensor,
         if len(corrs_loop) == n:
             corrs_lol.append(corrs_loop)
 
+    return corrs_lol
+
 
 def advariant(corrs_list: Union[List[List[torch.Tensor]], List[torch.Tensor]]) -> torch.Tensor:
     """

--- a/ClosureInvariants/scalarInvariants_torch.py
+++ b/ClosureInvariants/scalarInvariants_torch.py
@@ -93,6 +93,8 @@ def corrs_list_on_loops(corrs: torch.Tensor,
      [[correlation4], [correlation5], [correlation6]]]
     """
 
+    device = corrs.device
+    
     if not isinstance(ant_pairs, (list, NP.ndarray)):
         raise TypeError('Input ant_pairs must be a list or numpy array')
     ant_pairs = NP.array(ant_pairs)
@@ -122,29 +124,47 @@ def corrs_list_on_loops(corrs: torch.Tensor,
     elif loops.ndim != 2:
         raise ValueError('Input loops contains invalid shape')
 
+
+    # Map antenna label to integer index
+    ant_map = {}
+    for pair in ant_pairs:
+        for ant in pair:
+            if ant not in ant_map:
+                ant_map[ant] = len(ant_map)
+
+    # Lookup pair -> index and conjugation flag
+    pair_lookup = {}
+    for idx, (a, b) in enumerate(ant_pairs):
+        a_idx, b_idx = ant_map[a], ant_map[b]
+        pair_lookup[(a_idx, b_idx)] = (idx, False)
+        pair_lookup[(b_idx, a_idx)] = (idx, True)
+
+    # Convert loops to integer indices, skip missing
+    loops_idx = []
+    for loop in loops:
+        try:
+            loops_idx.append([ant_map[a] for a in loop])
+        except KeyError:
+            continue
+
     corrs_lol = []
-    for loopi, loop in enumerate(loops):
+    for loop in loops_idx:
         corrs_loop = []
-        for i in range(len(loop)):
-            bl_ind = NP.where((ant_pairs[:, 0] == loop[i]) & (ant_pairs[:, 1] == loop[(i + 1) % loop.size]))[0]
-            if bl_ind.size == 1:
-                corr = torch.clone(torch.index_select(corrs, bl_axis, torch.tensor(bl_ind)))
-            elif bl_ind.size == 0:  # Check for reversed pair
-                bl_ind = NP.where((ant_pairs[:, 0] == loop[(i + 1) % loop.size]) & (ant_pairs[:, 1] == loop[i]))[0]
-                if bl_ind.size == 0:
-                    raise IndexError('Specified antenna pair ({0},{1}) not found in input ant_pairs'.format(loop[i], loop[(i + 1) % loop.size]))
-                elif bl_ind.size == 1:  # Take conjugate
-                    corr = torch.index_select(corrs.conj(), bl_axis, torch.tensor(bl_ind))
-                elif bl_ind.size > 1:
-                    raise IndexError('{0} indices found for antenna pair ({1},{2}) in input ant_pairs'.format(bl_ind.size, loop[i], loop[(i + 1) % loop.size]))
-            elif bl_ind.size > 1:
-                raise IndexError('{0} indices found for antenna pair ({1},{2}) in input ant_pairs'.format(bl_ind.size, loop[i], loop[(i + 1) % loop.size]))
-        
-            corr = torch.index_select(corr, bl_axis, torch.tensor([0]))
-            corrs_loop.append(corr)
-        corrs_lol.append(corrs_loop)
-        
-    return corrs_lol
+        n = len(loop)
+        for i in range(n):
+            a, b = loop[i], loop[(i + 1) % n]
+            lookup = pair_lookup.get((a, b))
+            if lookup is not None:
+                idx, conj = lookup
+                corr = corrs.index_select(bl_axis, torch.tensor(idx, device=corrs.device))
+                if conj:
+                    corr = corr.conj()
+                corrs_loop.append(corr)
+            else:
+                break
+        if len(corrs_loop) == n:
+            corrs_lol.append(corrs_loop)
+
 
 def advariant(corrs_list: Union[List[List[torch.Tensor]], List[torch.Tensor]]) -> torch.Tensor:
     """

--- a/ClosureInvariants/vectorInvariants.py
+++ b/ClosureInvariants/vectorInvariants.py
@@ -150,29 +150,49 @@ def corrs_list_on_loops(corrs: NP.ndarray,
     tmpind = NP.where(pol_axes < 0)[0]
     if tmpind.size > 0:
         pol_axes[tmpind] += corrs.ndim # Convert to a positive value for the polarization axes
-        
+
+
+
+    # Map antenna label to integer index
+    ant_map = {}
+    for pair in ant_pairs:
+        for ant in pair:
+            if ant not in ant_map:
+                ant_map[ant] = len(ant_map)
+
+    # Lookup pair -> index and conjugation flag
+    pair_lookup = {}
+    for idx, (a, b) in enumerate(ant_pairs):
+        a_idx, b_idx = ant_map[a], ant_map[b]
+        pair_lookup[(a_idx, b_idx)] = (idx, False)
+        pair_lookup[(b_idx, a_idx)] = (idx, True)
+
+    # Convert loops to integer indices, skip missing
+    loops_idx = []
+    for loop in loops:
+        try:
+            loops_idx.append([ant_map[a] for a in loop])
+        except KeyError:
+            continue
+
+
     corrs_lol = []
-    for loopi, loop in enumerate(loops):
+    for loop in loops_idx:
         corrs_loop = []
-        for i in range(len(loop)):
-            bl_ind = NP.where((ant_pairs[:,0] == loop[i]) & (ant_pairs[:,1]==loop[(i+1)%loop.size]))[0]
-            if bl_ind.size == 1:
-                corr = NP.copy(NP.take(corrs, bl_ind, axis=bl_axis))
-            elif bl_ind.size == 0: # Check for reversed pair
-                bl_ind = NP.where((ant_pairs[:,0] == loop[(i+1)%loop.size]) & (ant_pairs[:,1]==loop[i]))[0]
-                if bl_ind.size == 0:
-                    raise IndexError('Specified antenna pair ({0:0d},{1:0d}) not found in input ant_pairs'.format(loop[i], loop[(i+1)%loop.size]))
-                elif bl_ind.size == 1: # Take Hermitian
-                    corr = MO.hermitian(NP.take(corrs, bl_ind, axis=bl_axis), axes=pol_axes)
-                elif bl_ind.size > 1:
-                    raise IndexError('{0:0d} indices found for antenna pair ({1:0d},{2:0d}) in input ant_pairs'.format(bl_ind, loop[i], loop[(i+1)%loop.size]))
-            elif bl_ind.size > 1:
-                raise IndexError('{0:0d} indices found for antenna pair ({1:0d},{2:0d}) in input ant_pairs'.format(bl_ind, loop[i], loop[(i+1)%loop.size]))
-        
-            corr = NP.take(corr, 0, axis=bl_axis)
-            corrs_loop += [corr]
-        corrs_lol += [corrs_loop]
-        
+        n = len(loop)
+        for i in range(n):
+            a, b = loop[i], loop[(i + 1) % n]
+            lookup = pair_lookup.get((a, b))
+            if lookup is not None:
+                idx, conj = lookup
+                corr = NP.copy(NP.take(corrs, idx, axis=bl_axis))
+                if conj:
+                    corr = NP.squeeze(MO.hermitian(NP.expand_dims(corr, axis=bl_axis), axes=pol_axes), axis=bl_axis)
+                corrs_loop.append(corr)
+            else:
+                break
+        if len(corrs_loop) == n:
+            corrs_lol.append(corrs_loop)
     return corrs_lol
 
 def advariant(corrs_list: Union[List[List[NP.ndarray]], List[NP.ndarray]], pol_axes: Union[List[int], tuple] = (-2, -1)) -> NP.ndarray:

--- a/ClosureInvariants/vectorInvariants_torch.py
+++ b/ClosureInvariants/vectorInvariants_torch.py
@@ -109,6 +109,9 @@ def corrs_list_on_loops(corrs: torch.Tensor,
      [[correlation4], [correlation5], [correlation6]]]
     """
 
+
+    device = corrs.device
+    
     if not isinstance(ant_pairs, (list, NP.ndarray)):
         raise TypeError('Input ant_pairs must be a list or numpy array')
     ant_pairs = NP.array(ant_pairs)
@@ -151,28 +154,48 @@ def corrs_list_on_loops(corrs: torch.Tensor,
     if tmpind.size().numel() > 0:
         pol_axes[tmpind] += corrs.ndim # Convert to a positive value for the polarization axes
         
+
+
+    # Map antenna label to integer index
+    ant_map = {}
+    for pair in ant_pairs:
+        for ant in pair:
+            if ant not in ant_map:
+                ant_map[ant] = len(ant_map)
+
+    # Lookup pair -> index and conjugation flag
+    pair_lookup = {}
+    for idx, (a, b) in enumerate(ant_pairs):
+        a_idx, b_idx = ant_map[a], ant_map[b]
+        pair_lookup[(a_idx, b_idx)] = (idx, False)
+        pair_lookup[(b_idx, a_idx)] = (idx, True)
+
+    # Convert loops to integer indices, skip missing
+    loops_idx = []
+    for loop in loops:
+        try:
+            loops_idx.append([ant_map[a] for a in loop])
+        except KeyError:
+            continue
+
     corrs_lol = []
-    for loopi, loop in enumerate(loops):
+    for loop in loops_idx:
         corrs_loop = []
-        for i in range(len(loop)):
-            bl_ind = NP.where((ant_pairs[:, 0] == loop[i]) & (ant_pairs[:, 1] == loop[(i + 1) % loop.size]))[0]
-            if bl_ind.size == 1:
-                corr = torch.clone(torch.index_select(corrs, bl_axis, torch.tensor(bl_ind)))
-            elif bl_ind.size == 0: # Check for reversed pair
-                bl_ind = NP.where((ant_pairs[:, 0] == loop[(i + 1) % loop.size]) & (ant_pairs[:, 1] == loop[i]))[0]
-                if bl_ind.size == 0:
-                    raise IndexError('Specified antenna pair ({0:0d},{1:0d}) not found in input ant_pairs'.format(loop[i], loop[(i + 1) % loop.size]))
-                elif bl_ind.size == 1: # Take Hermitian
-                    corr = hermitian(torch.index_select(corrs, bl_axis, torch.tensor(bl_ind)), axes=pol_axes)
-                elif bl_ind.size > 1:
-                    raise IndexError('{0:0d} indices found for antenna pair ({1:0d},{2:0d}) in input ant_pairs'.format(bl_ind, loop[i], loop[(i + 1) % loop.size]))
-            elif bl_ind.size > 1:
-                raise IndexError('{0:0d} indices found for antenna pair ({1:0d},{2:0d}) in input ant_pairs'.format(bl_ind, loop[i], loop[(i + 1) % loop.size]))
-        
-            corr = torch.index_select(corr, bl_axis, torch.tensor([0]))
-            corrs_loop += [corr]
-        corrs_lol += [corrs_loop]
-        
+        n = len(loop)
+        for i in range(n):
+            a, b = loop[i], loop[(i + 1) % n]
+            lookup = pair_lookup.get((a, b))
+            if lookup is not None:
+                idx, conj = lookup
+                corr = corrs.index_select(bl_axis, torch.tensor([idx], device=device))
+                if conj:
+                    corr = hermitian(corr, axes=pol_axes)
+                corrs_loop.append(corr)
+            else:
+                break
+
+        if len(corrs_loop) == n:
+            corrs_lol.append(corrs_loop)
     return corrs_lol
 
 def advariant(corrs_list: Union[List[List[torch.Tensor]], List[torch.Tensor]], pol_axes: Union[List[int], tuple] = (-2, -1)) -> torch.Tensor:

--- a/README.rst
+++ b/README.rst
@@ -11,6 +11,8 @@ https://github.com/nithyanandan/ClosureInvariants
 Installation
 ------------
 
+AstroUtils (https://github.com/nithyanandan/AstroUtils) is a dependency, so ensure it is installed first.
+
 To install ClosureInvariants, first clone the repository:
 
 .. code-block:: bash


### PR DESCRIPTION
Both numpy and torch versions of scalarInvariants and vectorInvariants have their corrs_list_on_loops function updated with index lookup table for efficiency.